### PR TITLE
Fixed incorrect number in getSummonerSpell2

### DIFF
--- a/src/com/robrua/orianna/type/core/currentgame/Participant.java
+++ b/src/com/robrua/orianna/type/core/currentgame/Participant.java
@@ -181,7 +181,7 @@ public class Participant extends OriannaObject<com.robrua.orianna.type.dto.curre
             return spell2;
         }
 
-        final Long l = data.getSpell1Id();
+        final Long l = data.getSpell2Id();
         if(l == null) {
             throw new MissingDataException("Summoner Spell #2 ID is null.");
         }


### PR DESCRIPTION
getSummonerSpell2() was calling data.getSpell1ID() instead of data.getSpell2ID()