### PR TITLE
Remove Invalid Seasons

### DIFF
--- a/src/com/robrua/orianna/type/core/common/Season.java
+++ b/src/com/robrua/orianna/type/core/common/Season.java
@@ -1,5 +1,5 @@
 package com.robrua.orianna.type.core.common;
 
 public enum Season {
-    PRESEASON2014, PRESEASON2015, PRESEASON3, SEASON2014, SEASON2015, SEASON3
+    SEASON2014, SEASON2015, SEASON3
 }


### PR DESCRIPTION
According to the official Riot API [here](https://developer.riotgames.com/api/methods#!/1018/3453), there exists only three query parameters: `SEASON3`, `SEASON2014`, and `SEASON2015`.
![screenshot](http://i.imgur.com/ogPqmCM.png)

I also get BAD_REQUEST (400) error when getting stats from PRESEASON Seasons.